### PR TITLE
fix method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ require 'nostr'
 
 ```ruby
 keygen  = Nostr::Keygen.new
-keypair = keygen.generate_keypair
+keypair = keygen.generate_key_pair
 
 keypair.private_key
 keypair.public_key


### PR DESCRIPTION
README had a misspelling of method name. Changed generate_keypair to generate_key_pair