### PR TITLE
Add event kinds for zap request and receipt

### DIFF
--- a/lib/nostr/event_kind.rb
+++ b/lib/nostr/event_kind.rb
@@ -40,5 +40,17 @@ module Nostr
     # @return [Integer]
     #
     ENCRYPTED_DIRECT_MESSAGE = 4
+
+    # A special event with kind 9374. See NIP-57.
+    #
+    # @return [Integer]
+    #
+    ZAP_REQUEST = 9734
+
+    # A special event with kind 9375. See NIP-57.
+    #
+    # @return [Integer]
+    #
+    ZAP_RECEIPT = 9735
   end
 end

--- a/spec/nostr/event_kind_spec.rb
+++ b/spec/nostr/event_kind_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe Nostr::EventKind do
       expect(described_class::ENCRYPTED_DIRECT_MESSAGE).to eq(4)
     end
   end
+
+  describe '::ZAP_REQUEST' do
+    it 'is an integer' do
+      expect(described_class::ZAP_REQUEST).to eq(9734)
+    end
+  end
+
+  describe '::ZAP_RECEIPT' do
+    it 'is an integer' do
+      expect(described_class::ZAP_RECEIPT).to eq(9735)
+    end
+  end
 end


### PR DESCRIPTION
A very small quality-of-life improvement.

(If someone's interested in a Rails integration of Nostr zaps (and lnurlp, lndhub-go) based on this gem, check out [akkounts](https://gitea.kosmos.org/kosmos/akkounts/src/branch/master/app/services/nostr_manager). Also includes Nostr logins with Devise and Stimulus. But beware, akkounts is mostly undocumented still, aiming for an October release of a self-hostable, documented codebase.)